### PR TITLE
Adding issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug Report
+about: Is something not working as expected? Please help us improve!
+title: ''
+labels: 'bug'
+---
+
+## Bug Report
+
+**Current behavior**
+A clear and concise description of what the bug is (with screenshots).
+
+**Reproduction**
+Steps to reproduce the behavior in the course:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Possible solution**
+If you have suggestions, we'd love to hear them. If not, that's ok too.
+
+**Additional context**
+Add any other context about the problem here. If applicable, add screenshots to help explain.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature Request
+about: I have a suggestion... and may want to implement it!
+title: ''
+labels: 'enhancement'
+---
+
+## Feature Request
+
+**Describe the problem/friction you are trying to solve**
+A clear and concise description of what the problem is, e.g. I am always frustrated when...
+
+**Describe your ideal solution**
+A clear and concise description of what you want to happen, ideally including code snippets to demonstrate usage examples.
+
+Add any considered drawbacks.
+
+**Describe alternatives you have considered**
+A clear and concise description of any alternative solutions or features you have considered.


### PR DESCRIPTION
I noticed that the bug and feature templates that are in the other courses are missing here.  Figured you might want them, so I copied over the ones from intro-to-html.

/cc @crichID @brianamarie @hectorsector @JasonEtco